### PR TITLE
Cdr 1270

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,4 @@ tsconfig.*
 babel.*
 jest.*
 .gitignore
-*.ts
+.npmignore

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # no-eval-handlebars
 
-This is a fork of @elastic/handlebars which some minor bugfixes.
+This is a fork of @elastic/handlebars with some minor bug fixes.
 
-A custom version of the handlebars package which, to improve security, does not use `eval` or `new Function`. This means that templates can't be compiled into JavaScript functions in advance and hence, rendering the templates is a lot slower.
+@elastic/handlebars is a custom version of the handlebars package which, to improve security, does not use `eval` or `new Function`. This means that templates can't be compiled into JavaScript functions in advance and hence, rendering the templates is a lot slower.
 
 ## Limitations
 

--- a/src/handlebars.ts
+++ b/src/handlebars.ts
@@ -5,7 +5,7 @@
 
 // The handlebars module uses `export =`, so we should technically use `import Handlebars = require('handlebars')`, but Babel will not allow this:
 // https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require
-import Handlebars from 'handlebars';
+import Handlebars from 'handlebars/dist/handlebars';
 
 import type { CompileOptions, RuntimeOptions, TemplateDelegate } from './types';
 import { ElasticHandlebarsVisitor } from './visitor';

--- a/src/spec/index.blocks.test.ts
+++ b/src/spec/index.blocks.test.ts
@@ -307,7 +307,6 @@ describe('blocks', () => {
             });
 
             it('unregisters', () => {
-                // @ts-expect-error: Cannot assign to 'decorators' because it is a read-only property.
                 kbnHandlebarsEnv!.decorators = {};
 
                 kbnHandlebarsEnv!.registerDecorator('foo', function () {
@@ -320,10 +319,8 @@ describe('blocks', () => {
             });
 
             it('allows multiple globals', () => {
-                // @ts-expect-error: Cannot assign to 'decorators' because it is a read-only property.
                 kbnHandlebarsEnv!.decorators = {};
 
-                // @ts-expect-error: Expected 2 arguments, but got 1.
                 kbnHandlebarsEnv!.registerDecorator({
                     foo() {},
                     bar() {},
@@ -340,7 +337,6 @@ describe('blocks', () => {
             it('fails with multiple and args', () => {
                 expect(() => {
                     kbnHandlebarsEnv!.registerDecorator(
-                        // @ts-expect-error: Argument of type '{ world(): string; testHelper(): string; }' is not assignable to parameter of type 'string'.
                         {
                             world() {
                                 return 'world!';

--- a/src/spec/index.builtins.test.ts
+++ b/src/spec/index.builtins.test.ts
@@ -483,7 +483,7 @@ describe('builtin helpers', () => {
         it('should call logger at default level', function () {
             let levelArg;
             let logArg;
-            kbnHandlebarsEnv!.log = function (level, arg) {
+            kbnHandlebarsEnv!.log = function (level: number, arg: string) {
                 levelArg = level;
                 logArg = arg;
             };
@@ -496,7 +496,7 @@ describe('builtin helpers', () => {
         it('should call logger at data level', function () {
             let levelArg;
             let logArg;
-            kbnHandlebarsEnv!.log = function (level, arg) {
+            kbnHandlebarsEnv!.log = function (level: number, arg: string) {
                 levelArg = level;
                 logArg = arg;
             };

--- a/src/spec/index.helpers.test.ts
+++ b/src/spec/index.helpers.test.ts
@@ -380,7 +380,6 @@ describe('helpers', () => {
         it('fails with multiple and args', () => {
             expect(() => {
                 kbnHandlebarsEnv!.registerHelper(
-                    // @ts-expect-error TypeScript is complaining about the invalid input just as the thrown error
                     {
                         world() {
                             return 'world!';

--- a/src/types/handlebars-dist.d.ts
+++ b/src/types/handlebars-dist.d.ts
@@ -1,14 +1,9 @@
-import 'handlebars';
-import type {
-    HelperDelegate as HelperDelegateFixed,
-    TemplateDelegate as TemplateDelegateFixed,
-    Template as TemplateFixed,
-} from './types';
-
 /**
  * A custom version of the Handlebars module with an extra `compileAST` function and fixed typings.
  */
-declare module 'handlebars' {
+declare module 'handlebars/dist/handlebars' {
+    import * as Handlebars from 'handlebars/dist/handlebars';
+
     /**
      * Compiles the given Handlebars template without the use of `eval`.
      *
@@ -48,4 +43,6 @@ declare module 'handlebars' {
      * @param spec A key/value object where each key is the name of a partial (a string) and each value is the partial (either a string or a partial function).
      */
     export function registerPartial(spec: Record<string, TemplateFixed>): void; // Ensure `spec` object values can be strings
+
+    export = Handlebars;
 }

--- a/src/types/handlebars.d.ts
+++ b/src/types/handlebars.d.ts
@@ -1,0 +1,51 @@
+import 'handlebars';
+import type {
+    HelperDelegate as HelperDelegateFixed,
+    TemplateDelegate as TemplateDelegateFixed,
+    Template as TemplateFixed,
+} from './types';
+
+/**
+ * A custom version of the Handlebars module with an extra `compileAST` function and fixed typings.
+ */
+declare module 'handlebars' {
+    /**
+     * Compiles the given Handlebars template without the use of `eval`.
+     *
+     * @returns A render function with the same API as the return value from the regular Handlebars `compile` function.
+     */
+    export function compileAST(input: string | hbs.AST.Program, options?: CompileOptions): TemplateDelegateFixed;
+
+    // --------------------------------------------------------
+    // Override/Extend inherited funcions and interfaces below that are incorrect.
+    //
+    // Any exported `const` or `type` types can't be overwritten, so we'll just
+    // have to live with those and cast them to the correct types in our code.
+    // Some of these fixed types, we'll instead export outside the scope of this
+    // 'handlebars' module so consumers of @elastic/handlebars at least have a way to
+    // access the correct types.
+    // --------------------------------------------------------
+
+    /**
+     * A {@link https://handlebarsjs.com/api-reference/helpers.html helper-function} type.
+     *
+     * When registering a helper function, it should be of this type.
+     */
+    export interface HelperDelegate extends HelperDelegateFixed {} // eslint-disable-line @typescript-eslint/no-empty-interface
+
+    /**
+     * A template-function type.
+     *
+     * This type is primarily used for the return value of by calls to
+     * {@link https://handlebarsjs.com/api-reference/compilation.html#handlebars-compile-template-options Handlebars.compile},
+     * Handlebars.compileAST and {@link https://handlebarsjs.com/api-reference/compilation.html#handlebars-precompile-template-options Handlebars.template}.
+     */
+    export interface TemplateDelegate<T = any> extends TemplateDelegateFixed<T> {} // eslint-disable-line @typescript-eslint/no-empty-interface
+
+    /**
+     * Register one or more {@link https://handlebarsjs.com/api-reference/runtime.html#handlebars-registerpartial-name-partial partials}.
+     *
+     * @param spec A key/value object where each key is the name of a partial (a string) and each value is the partial (either a string or a partial function).
+     */
+    export function registerPartial(spec: Record<string, TemplateFixed>): void; // Ensure `spec` object values can be strings
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -3,7 +3,8 @@
  * See `packages/kbn-handlebars/LICENSE` for more information.
  */
 
-import { kHelper, kAmbiguous, kSimple } from './symbols';
+import { kHelper, kAmbiguous, kSimple } from '../symbols';
+import 'handlebars';
 
 // Unexported `CompileOptions` lifted from node_modules/handlebars/types/index.d.ts
 // While it could also be extracted using `NonNullable<Parameters<typeof Handlebars.compile>[1]>`, this isn't possible since we declare the handlebars module below
@@ -18,51 +19,6 @@ interface HandlebarsCompileOptions {
     preventIndent?: boolean;
     ignoreStandalone?: boolean;
     explicitPartialContext?: boolean;
-}
-
-/**
- * A custom version of the Handlebars module with an extra `compileAST` function and fixed typings.
- */
-declare module 'handlebars' {
-    /**
-     * Compiles the given Handlebars template without the use of `eval`.
-     *
-     * @returns A render function with the same API as the return value from the regular Handlebars `compile` function.
-     */
-    export function compileAST(input: string | hbs.AST.Program, options?: CompileOptions): TemplateDelegateFixed;
-
-    // --------------------------------------------------------
-    // Override/Extend inherited funcions and interfaces below that are incorrect.
-    //
-    // Any exported `const` or `type` types can't be overwritten, so we'll just
-    // have to live with those and cast them to the correct types in our code.
-    // Some of these fixed types, we'll instead export outside the scope of this
-    // 'handlebars' module so consumers of @elastic/handlebars at least have a way to
-    // access the correct types.
-    // --------------------------------------------------------
-
-    /**
-     * A {@link https://handlebarsjs.com/api-reference/helpers.html helper-function} type.
-     *
-     * When registering a helper function, it should be of this type.
-     */
-    export interface HelperDelegate extends HelperDelegateFixed {} // eslint-disable-line @typescript-eslint/no-empty-interface
-
-    /**
-     * A template-function type.
-     *
-     * This type is primarily used for the return value of by calls to
-     * {@link https://handlebarsjs.com/api-reference/compilation.html#handlebars-compile-template-options Handlebars.compile},
-     * Handlebars.compileAST and {@link https://handlebarsjs.com/api-reference/compilation.html#handlebars-precompile-template-options Handlebars.template}.
-     */
-    export interface TemplateDelegate<T = any> extends TemplateDelegateFixed<T> {} // eslint-disable-line @typescript-eslint/no-empty-interface
-
-    /**
-     * Register one or more {@link https://handlebarsjs.com/api-reference/runtime.html#handlebars-registerpartial-name-partial partials}.
-     *
-     * @param spec A key/value object where each key is the name of a partial (a string) and each value is the partial (either a string or a partial function).
-     */
-    export function registerPartial(spec: Record<string, TemplateFixed>): void; // Ensure `spec` object values can be strings
 }
 
 /**

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -2,8 +2,7 @@
  * Elasticsearch B.V licenses this file to you under the MIT License.
  * See `packages/kbn-handlebars/LICENSE` for more information.
  */
-
-import Handlebars from 'handlebars';
+import Handlebars from 'handlebars/dist/handlebars';
 import {
     createProtoAccessControl,
     resultIsAllowed,
@@ -173,27 +172,31 @@ export class ElasticHandlebarsVisitor extends Handlebars.Visitor {
         // Alternatively any of the root decorators might call the `defaultMain`
         // function themselves, process its return value, and return a completely
         // different `main` function.
-        const main = this.processDecorators(this.ast, defaultMain);
-        this.processedRootDecorators = true;
+        if (this.ast) {
+            const main = this.processDecorators(this.ast, defaultMain);
+            this.processedRootDecorators = true;
 
-        // Call the `main` function and add the result to the final output.
-        const result = main(this.context, options);
+            // Call the `main` function and add the result to the final output.
+            const result = main(this.context, options);
 
-        if (main === defaultMain) {
-            this.output.push(result);
-            return this.output.join('');
-        } else {
-            // We normally expect the return value of `main` to be a string. However,
-            // if a decorator is used to override the `defaultMain` function, the
-            // return value can be any type. To match the upstream handlebars project
-            // behavior, we want the result of rendering the template to be the
-            // literal value returned by the decorator.
-            //
-            // Since the output array in this case always will be empty, we just
-            // return that single value instead of attempting to join all the array
-            // elements as strings.
-            return result;
+            if (main === defaultMain) {
+                this.output.push(result);
+                return this.output.join('');
+            } else {
+                // We normally expect the return value of `main` to be a string. However,
+                // if a decorator is used to override the `defaultMain` function, the
+                // return value can be any type. To match the upstream handlebars project
+                // behavior, we want the result of rendering the template to be the
+                // literal value returned by the decorator.
+                //
+                // Since the output array in this case always will be empty, we just
+                // return that single value instead of attempting to join all the array
+                // elements as strings.
+                return result;
+            }
         }
+
+        return '';
     }
 
     // ********************************************** //
@@ -744,9 +747,9 @@ export class ElasticHandlebarsVisitor extends Handlebars.Visitor {
         this.output = [];
 
         if (Array.isArray(nodes)) {
-            this.acceptArray(nodes);
+            super.acceptArray(nodes);
         } else {
-            this.accept(nodes);
+            super.accept(nodes);
         }
 
         const result = this.output;


### PR DESCRIPTION
Rather than using `import Handlebars from 'handlebars'`, use `'import Handlebars from 'handlebars/dist/handlebars'`. This resolves issues in some projects where Handlebars would end up becoming undefined. The root cause of the issue is still up in the air, but this seems to resolve it.

This changes the import statement and alters other files to fix typescript-related issues. It also adds a module declaration file for `handlebars/dist/handlebars`.